### PR TITLE
Fix: Put 'https' in 'next' field on list_channels pagination

### DIFF
--- a/marketplace/connect/client.py
+++ b/marketplace/connect/client.py
@@ -36,7 +36,9 @@ class ConnectProjectClient(ConnectAuth):
         while response.json().get("next") is not None and response.status_code == 200:
             for channel in response.json().get("results"):
                 channels.append(channel)
-            response = requests.get(url=response.json().get("next"), json=payload, headers=self.auth_header())
+            response = requests.get(
+                url=response.json().get("next").replace("http:", "https:"), json=payload, headers=self.auth_header()
+            )
 
         return channels
 
@@ -52,12 +54,12 @@ class ConnectProjectClient(ConnectAuth):
             "user": user,
             "project_uuid": str(project_uuid),
             "config": json.dumps(config),
-            "phone_number_id": phone_number_id
+            "phone_number_id": phone_number_id,
         }
         response = requests.post(
             url=self.base_url + "/v1/organization/project/create_wac_channel/",
             json=payload,
-            headers=self.auth_header()
+            headers=self.auth_header(),
         )
         return response.json()
 


### PR DESCRIPTION
# Resume
Inside of method **list_channels**, we create a pagination to receive long list of items, so the server return a field called "next" with next page as content, now it's returning with `http`, it's cause a bad request.
This PR aims to solve this problem.