### PR TITLE
Adjust the way the config is being saved in the WAC sync task

### DIFF
--- a/marketplace/core/types/channels/whatsapp_cloud/tasks.py
+++ b/marketplace/core/types/channels/whatsapp_cloud/tasks.py
@@ -55,7 +55,7 @@ def sync_whatsapp_cloud_apps():
                     logger.info(f"Migrating an {app.code} to WhatsApp Cloud Type. App: {app.uuid}")
                     app.code = apptype.code
 
-                app.config = config
+                app.config.update(config)
                 app.modified_by = user
                 app.save()
 

--- a/marketplace/core/types/channels/whatsapp_cloud/tasks.py
+++ b/marketplace/core/types/channels/whatsapp_cloud/tasks.py
@@ -44,8 +44,6 @@ def sync_whatsapp_cloud_apps():
             config["title"] = config.get("wa_number")
             config["wa_phone_number_id"] = address
 
-            # TODO: Add title and address to config
-
             apps = App.objects.filter(flow_object_uuid=uuid)
 
             if apps.exists():
@@ -54,8 +52,11 @@ def sync_whatsapp_cloud_apps():
                 if app.code != apptype.code:
                     logger.info(f"Migrating an {app.code} to WhatsApp Cloud Type. App: {app.uuid}")
                     app.code = apptype.code
+                    config["config_before_migration"] = app.config
+                    app.config = config
+                else:
+                    app.config.update(config)
 
-                app.config.update(config)
                 app.modified_by = user
                 app.save()
 

--- a/marketplace/core/types/channels/whatsapp_cloud/tests/test_tasks.py
+++ b/marketplace/core/types/channels/whatsapp_cloud/tests/test_tasks.py
@@ -1,3 +1,4 @@
+import json
 from uuid import uuid4
 from typing import TYPE_CHECKING
 from unittest.mock import patch
@@ -20,18 +21,18 @@ User = get_user_model()
 class SyncWhatsAppCloudAppsTaskTestCase(TestCase):
     def setUp(self) -> None:
 
-        wpp_type = APPTYPES.get("wpp-cloud")
+        wpp_type = APPTYPES.get("wpp")
         wpp_cloud_type = APPTYPES.get("wpp-cloud")
 
         self.wpp_app = wpp_type.create_app(
-            config={},
+            config={"have_to_stay": "fake"},
             project_uuid=uuid4(),
             flow_object_uuid=uuid4(),
             created_by=User.objects.get_admin_user(),
         )
 
         self.wpp_cloud_app = wpp_cloud_type.create_app(
-            config={},
+            config={"have_to_stay": "fake"},
             project_uuid=uuid4(),
             flow_object_uuid=uuid4(),
             created_by=User.objects.get_admin_user(),
@@ -40,12 +41,19 @@ class SyncWhatsAppCloudAppsTaskTestCase(TestCase):
         return super().setUp()
 
     def _get_mock_value(self, project_uuid: str, flow_object_uuid: str) -> list:
+        config = {"wa_number": "+55829926642"}
+
         return [
             {
                 "channel_data": {
                     "project_uuid": project_uuid,
                     "channels": [
-                        {"uuid": flow_object_uuid, "name": "Fake Name", "config": "{}", "address": "+55829946542"}
+                        {
+                            "uuid": flow_object_uuid,
+                            "name": "Fake Name",
+                            "config": json.dumps(config),
+                            "address": "343964803908140",
+                        }
                     ],
                 }
             }
@@ -61,6 +69,20 @@ class SyncWhatsAppCloudAppsTaskTestCase(TestCase):
 
         app = App.objects.get(id=self.wpp_app.id)
         self.assertEqual(app.code, "wpp-cloud")
+        self.assertIn("config_before_migration", app.config)
+        self.assertIn("have_to_stay", app.config.get("config_before_migration"))
+
+    @patch("marketplace.connect.client.ConnectProjectClient.list_channels")
+    def test_sync_for_non_migrated_channels(self, list_channel_mock: "MagicMock") -> None:
+        list_channel_mock.return_value = self._get_mock_value(
+            str(self.wpp_cloud_app.project_uuid), str(self.wpp_cloud_app.flow_object_uuid)
+        )
+
+        sync_whatsapp_cloud_apps()
+
+        app = App.objects.get(id=self.wpp_cloud_app.id)
+        self.assertEqual(app.code, "wpp-cloud")
+        self.assertIn("have_to_stay", app.config)
 
     @patch("marketplace.connect.client.ConnectProjectClient.list_channels")
     def test_create_new_whatsapp_cloud(self, list_channel_mock: "MagicMock") -> None:


### PR DESCRIPTION
In the way it was before, some information could be lost, in the current way it will only happen the overlap of the keys that come from the channel in Flows.