### PR TITLE
Whatsapp Conversation WABA Fix

### DIFF
--- a/marketplace/core/types/channels/whatsapp/views.py
+++ b/marketplace/core/types/channels/whatsapp/views.py
@@ -34,6 +34,16 @@ class WhatsAppViewSet(
         return Response("This channel cannot be deleted", status=status.HTTP_403_FORBIDDEN)
 
     @property
+    def app_waba_id(self) -> dict:
+        config = self.get_object().config
+        waba_id = config.get("fb_business_id", None)
+
+        if waba_id is None:
+            raise ValidationError("This app does not have WABA (Whatsapp Business Account ID) configured")
+
+        return waba_id
+
+    @property
     def profile_config_credentials(self) -> dict:
         config = self.get_object().config
         base_url = config.get("base_url", None)

--- a/marketplace/core/types/channels/whatsapp_cloud/views.py
+++ b/marketplace/core/types/channels/whatsapp_cloud/views.py
@@ -37,6 +37,16 @@ class WhatsAppCloudViewSet(
     profile_class = CloudProfileFacade
 
     @property
+    def app_waba_id(self) -> dict:
+        config = self.get_object().config
+        waba_id = config.get("wa_waba_id", None)
+
+        if waba_id is None:
+            raise ValidationError("This app does not have WABA (Whatsapp Business Account ID) configured")
+
+        return waba_id
+
+    @property
     def profile_config_credentials(self) -> dict:
         config = self.get_object().config
         phone_numbrer_id = config.get("wa_phone_number_id", None)


### PR DESCRIPTION
**Problem**
The conversations feature was not working on Whatsapp Cloud, the mixin developed to work on both whatsapp was trying to search for a field that did not exist in the WAC app.

**Solution**
Was added a property that must be overridden in any view that inherits the `WhatsAppConversationsMixin`.