### PR TITLE
Adjust the call to Connect in the list channels endpoint

### DIFF
--- a/marketplace/connect/client.py
+++ b/marketplace/connect/client.py
@@ -26,21 +26,12 @@ class ConnectProjectClient(ConnectAuth):
     base_url = settings.CONNECT_ENGINE_BASE_URL
 
     def list_channels(self, channeltype_code: str) -> list:
-        channels = []
 
-        payload = {"channel_type": channeltype_code}
+        params = {"channel_type": channeltype_code}
         response = requests.get(
-            url=self.base_url + "/v1/organization/project/list_channel/", json=payload, headers=self.auth_header()
+            url=self.base_url + "/v1/organization/project/list_channels/", params=params, headers=self.auth_header()
         )
-
-        while response.json().get("next") is not None and response.status_code == 200:
-            for channel in response.json().get("results"):
-                channels.append(channel)
-            response = requests.get(
-                url=response.json().get("next").replace("http:", "https:"), json=payload, headers=self.auth_header()
-            )
-
-        return channels
+        return response.json()
 
     def create_channel(self, user: str, project_uuid: str, data: dict, channeltype_code: str) -> dict:
         payload = {"user": user, "project_uuid": str(project_uuid), "data": data, "channeltype_code": channeltype_code}

--- a/marketplace/connect/client.py
+++ b/marketplace/connect/client.py
@@ -31,7 +31,7 @@ class ConnectProjectClient(ConnectAuth):
         response = requests.get(
             url=self.base_url + "/v1/organization/project/list_channels/", params=params, headers=self.auth_header()
         )
-        return response.json()
+        return response.json().get("channels", None)
 
     def create_channel(self, user: str, project_uuid: str, data: dict, channeltype_code: str) -> dict:
         payload = {"user": user, "project_uuid": str(project_uuid), "data": data, "channeltype_code": channeltype_code}

--- a/marketplace/core/types/channels/whatsapp_cloud/tasks.py
+++ b/marketplace/core/types/channels/whatsapp_cloud/tasks.py
@@ -22,7 +22,7 @@ SYNC_WHATSAPP_CLOUD_LOCK_KEY = "sync-whatsapp-cloud-lock"
 def sync_whatsapp_cloud_apps():
     apptype = APPTYPES.get("wpp-cloud")
     client = ConnectProjectClient()
-    projects = client.list_channels(apptype.channeltype_code)
+    channels = client.list_channels(apptype.channeltype_code)
 
     redis = get_redis_connection()
 
@@ -30,40 +30,41 @@ def sync_whatsapp_cloud_apps():
         logger.info("The apps are already syncing by another task!")
         return None
 
-    for project in projects:
+    for channel in channels:
 
-        channel_data = project.get("channel_data", {})
-        project_uuid = channel_data.get("project_uuid")
+        project_uuid = channel.get("project_uuid")
 
-        for channel in channel_data.get("channels", []):
-            uuid = channel.get("uuid")
-            address = channel.get("address")
-            user = User.objects.get_admin_user()
+        uuid = channel.get("uuid")
+        address = channel.get("address")
+        user = User.objects.get_admin_user()
 
-            config = json.loads(channel.get("config"))
-            config["title"] = config.get("wa_number")
-            config["wa_phone_number_id"] = address
+        config = json.loads(channel.get("config"))
+        config["title"] = config.get("wa_number")
+        config["wa_phone_number_id"] = address
 
-            # TODO: Add title and address to config
+        # TODO: Add title and address to config
 
-            apps = App.objects.filter(flow_object_uuid=uuid)
+        apps = App.objects.filter(flow_object_uuid=uuid)
 
-            if apps.exists():
-                app = apps.first()
+        if apps.exists():
+            app = apps.first()
 
-                if app.code != apptype.code:
-                    logger.info(f"Migrating an {app.code} to WhatsApp Cloud Type. App: {app.uuid}")
-                    app.code = apptype.code
-
+            if app.code != apptype.code:
+                logger.info(f"Migrating an {app.code} to WhatsApp Cloud Type. App: {app.uuid}")
+                app.code = apptype.code
+                config["config_before_migration"] = app.config
                 app.config = config
-                app.modified_by = user
-                app.save()
-
             else:
-                logger.info(f"Creating a new WhatsApp Cloud app for the flow_object_uuid: {uuid}")
-                apptype.create_app(
-                    created_by=user,
-                    project_uuid=project_uuid,
-                    flow_object_uuid=uuid,
-                    config=config,
-                )
+                app.config.update(config)
+
+            app.modified_by = user
+            app.save()
+
+        else:
+            logger.info(f"Creating a new WhatsApp Cloud app for the flow_object_uuid: {uuid}")
+            apptype.create_app(
+                created_by=user,
+                project_uuid=project_uuid,
+                flow_object_uuid=uuid,
+                config=config,
+            )

--- a/marketplace/core/types/channels/whatsapp_cloud/tests/test_tasks.py
+++ b/marketplace/core/types/channels/whatsapp_cloud/tests/test_tasks.py
@@ -20,18 +20,18 @@ User = get_user_model()
 class SyncWhatsAppCloudAppsTaskTestCase(TestCase):
     def setUp(self) -> None:
 
-        wpp_type = APPTYPES.get("wpp-cloud")
+        wpp_type = APPTYPES.get("wpp")
         wpp_cloud_type = APPTYPES.get("wpp-cloud")
 
         self.wpp_app = wpp_type.create_app(
-            config={},
+            config={"have_to_stay": "fake"},
             project_uuid=uuid4(),
             flow_object_uuid=uuid4(),
             created_by=User.objects.get_admin_user(),
         )
 
         self.wpp_cloud_app = wpp_cloud_type.create_app(
-            config={},
+            config={"have_to_stay": "fake"},
             project_uuid=uuid4(),
             flow_object_uuid=uuid4(),
             created_by=User.objects.get_admin_user(),
@@ -42,12 +42,12 @@ class SyncWhatsAppCloudAppsTaskTestCase(TestCase):
     def _get_mock_value(self, project_uuid: str, flow_object_uuid: str) -> list:
         return [
             {
-                "channel_data": {
-                    "project_uuid": project_uuid,
-                    "channels": [
-                        {"uuid": flow_object_uuid, "name": "Fake Name", "config": "{}", "address": "+55829946542"}
-                    ],
-                }
+                "uuid": flow_object_uuid,
+                "name": "teste",
+                "config": "{}",
+                "address": "f234234",
+                "project_uuid": project_uuid,
+                "is_active": True,
             }
         ]
 
@@ -61,6 +61,20 @@ class SyncWhatsAppCloudAppsTaskTestCase(TestCase):
 
         app = App.objects.get(id=self.wpp_app.id)
         self.assertEqual(app.code, "wpp-cloud")
+        self.assertIn("config_before_migration", app.config)
+        self.assertIn("have_to_stay", app.config.get("config_before_migration"))
+
+    @patch("marketplace.connect.client.ConnectProjectClient.list_channels")
+    def test_sync_for_non_migrated_channels(self, list_channel_mock: "MagicMock") -> None:
+        list_channel_mock.return_value = self._get_mock_value(
+            str(self.wpp_cloud_app.project_uuid), str(self.wpp_cloud_app.flow_object_uuid)
+        )
+
+        sync_whatsapp_cloud_apps()
+
+        app = App.objects.get(id=self.wpp_cloud_app.id)
+        self.assertEqual(app.code, "wpp-cloud")
+        self.assertIn("have_to_stay", app.config)
 
     @patch("marketplace.connect.client.ConnectProjectClient.list_channels")
     def test_create_new_whatsapp_cloud(self, list_channel_mock: "MagicMock") -> None:


### PR DESCRIPTION
This endpoint had a low performance because it was project-oriented and not channel-oriented, that is: for each project a request was made for the flows, even when the project did not have any channel, and this generated timeouts. This PR aims to solve such problems

Main Changes:
- Pass data from query params instead of body
- Adjust call path, replace list_channel with list_channels
- Remove pagination as it will no longer be needed