### PR TITLE
Adjust task that syncs WhatsApp Cloud channels

### DIFF
--- a/marketplace/core/types/channels/whatsapp_cloud/tasks.py
+++ b/marketplace/core/types/channels/whatsapp_cloud/tasks.py
@@ -22,7 +22,7 @@ SYNC_WHATSAPP_CLOUD_LOCK_KEY = "sync-whatsapp-cloud-lock"
 def sync_whatsapp_cloud_apps():
     apptype = APPTYPES.get("wpp-cloud")
     client = ConnectProjectClient()
-    projects = client.list_channels(apptype.channeltype_code)
+    channels = client.list_channels(apptype.channeltype_code)
 
     redis = get_redis_connection()
 
@@ -30,40 +30,38 @@ def sync_whatsapp_cloud_apps():
         logger.info("The apps are already syncing by another task!")
         return None
 
-    for project in projects:
+    for channel in channels:
 
-        channel_data = project.get("channel_data", {})
-        project_uuid = channel_data.get("project_uuid")
+        project_uuid = channel.get("project_uuid")
 
-        for channel in channel_data.get("channels", []):
-            uuid = channel.get("uuid")
-            address = channel.get("address")
-            user = User.objects.get_admin_user()
+        uuid = channel.get("uuid")
+        address = channel.get("address")
+        user = User.objects.get_admin_user()
 
-            config = json.loads(channel.get("config"))
-            config["title"] = config.get("wa_number")
-            config["wa_phone_number_id"] = address
+        config = json.loads(channel.get("config"))
+        config["title"] = config.get("wa_number")
+        config["wa_phone_number_id"] = address
 
-            # TODO: Add title and address to config
+        # TODO: Add title and address to config
 
-            apps = App.objects.filter(flow_object_uuid=uuid)
+        apps = App.objects.filter(flow_object_uuid=uuid)
 
-            if apps.exists():
-                app = apps.first()
+        if apps.exists():
+            app = apps.first()
 
-                if app.code != apptype.code:
-                    logger.info(f"Migrating an {app.code} to WhatsApp Cloud Type. App: {app.uuid}")
-                    app.code = apptype.code
+            if app.code != apptype.code:
+                logger.info(f"Migrating an {app.code} to WhatsApp Cloud Type. App: {app.uuid}")
+                app.code = apptype.code
 
-                app.config = config
-                app.modified_by = user
-                app.save()
+            app.config = config
+            app.modified_by = user
+            app.save()
 
-            else:
-                logger.info(f"Creating a new WhatsApp Cloud app for the flow_object_uuid: {uuid}")
-                apptype.create_app(
-                    created_by=user,
-                    project_uuid=project_uuid,
-                    flow_object_uuid=uuid,
-                    config=config,
-                )
+        else:
+            logger.info(f"Creating a new WhatsApp Cloud app for the flow_object_uuid: {uuid}")
+            apptype.create_app(
+                created_by=user,
+                project_uuid=project_uuid,
+                flow_object_uuid=uuid,
+                config=config,
+            )

--- a/marketplace/core/types/channels/whatsapp_cloud/tasks.py
+++ b/marketplace/core/types/channels/whatsapp_cloud/tasks.py
@@ -52,8 +52,11 @@ def sync_whatsapp_cloud_apps():
             if app.code != apptype.code:
                 logger.info(f"Migrating an {app.code} to WhatsApp Cloud Type. App: {app.uuid}")
                 app.code = apptype.code
+                config["config_before_migration"] = app.config
+                app.config = config
+            else:
+                app.config.update(config)
 
-            app.config = config
             app.modified_by = user
             app.save()
 

--- a/marketplace/core/types/channels/whatsapp_cloud/tests/test_tasks.py
+++ b/marketplace/core/types/channels/whatsapp_cloud/tests/test_tasks.py
@@ -20,7 +20,7 @@ User = get_user_model()
 class SyncWhatsAppCloudAppsTaskTestCase(TestCase):
     def setUp(self) -> None:
 
-        wpp_type = APPTYPES.get("wpp-cloud")
+        wpp_type = APPTYPES.get("wpp")
         wpp_cloud_type = APPTYPES.get("wpp-cloud")
 
         self.wpp_app = wpp_type.create_app(
@@ -42,12 +42,12 @@ class SyncWhatsAppCloudAppsTaskTestCase(TestCase):
     def _get_mock_value(self, project_uuid: str, flow_object_uuid: str) -> list:
         return [
             {
-                "channel_data": {
-                    "project_uuid": project_uuid,
-                    "channels": [
-                        {"uuid": flow_object_uuid, "name": "Fake Name", "config": "{}", "address": "+55829946542"}
-                    ],
-                }
+                "uuid": flow_object_uuid,
+                "name": "teste",
+                "config": "{}",
+                "address": "f234234",
+                "project_uuid": project_uuid,
+                "is_active": True,
             }
         ]
 


### PR DESCRIPTION
The channel listing endpoint was underperforming because it was project-oriented and not channel-oriented, that is: for each project, a request was made for the flows, even when the project had no channel and this generated timeouts. This PR aims to solve such problems.

When adjusting the endpoint, it was also necessary to adjust the WhatsApp Cloud task that synchronizes the apps.