### PR TITLE
Fix/Release Channel work without gRPC

### DIFF
--- a/marketplace/core/types/views.py
+++ b/marketplace/core/types/views.py
@@ -30,6 +30,6 @@ class BaseAppTypeViewSet(CreateModelMixin, RetrieveModelMixin, UpdateModelMixin,
 
         channel_uuid = instance.config.get("channelUuid")
 
-        if channel_uuid is not None and settings.USE_GRPC:
+        if channel_uuid:
             client = ConnectProjectClient()
             client.release_channel(channel_uuid, self.request.user.email)


### PR DESCRIPTION
## Resume
To release channel work correctly the `USE_GRPC` settings key need to be true, but this is'nt needed now. 