### PR TITLE
Fix/Remove unecessary to do

### DIFF
--- a/marketplace/core/types/channels/whatsapp_cloud/tasks.py
+++ b/marketplace/core/types/channels/whatsapp_cloud/tasks.py
@@ -42,8 +42,6 @@ def sync_whatsapp_cloud_apps():
         config["title"] = config.get("wa_number")
         config["wa_phone_number_id"] = address
 
-        # TODO: Add title and address to config
-
         apps = App.objects.filter(flow_object_uuid=uuid)
 
         if apps.exists():


### PR DESCRIPTION
## Resume
In **sync_whatsapp_cloud_apps** task has a unecessary todo.
```
config = json.loads(channel.get("config"))
config["title"] = config.get("wa_number")
config["wa_phone_number_id"] = address

# TODO: Add title and address to config
```
The title and addres alredy added on config.