### PR TITLE
Fix/Whatsapp Cloud sync does not working

### DIFF
--- a/marketplace/connect/client.py
+++ b/marketplace/connect/client.py
@@ -44,7 +44,7 @@ class ConnectProjectClient(ConnectAuth):
         payload = {
             "user": user,
             "project_uuid": str(project_uuid),
-            "config": json.dumps(config),
+            "config": config,
             "phone_number_id": phone_number_id,
         }
         response = requests.post(


### PR DESCRIPTION
## Resume
We did a update that discontinue gRPC, now we don't need pass json like a string more.