### PR TITLE
Removes `,` which was turning the URL into a tuple when concatenated

### DIFF
--- a/marketplace/connect/client.py
+++ b/marketplace/connect/client.py
@@ -79,7 +79,7 @@ class ConnectProjectClient(ConnectAuth):
         }
         if self.use_connect_v2:
             del payload["project_uuid"]
-            url = self.base_url + f"/v2/projects/{project_uuid}/create-wac-channel/",
+            url = self.base_url + f"/v2/projects/{project_uuid}/create-wac-channel/"
         else:
             url = self.base_url + "/v1/organization/project/create_wac_channel/"
 


### PR DESCRIPTION
When concatenating the base URL with the endpoint it was returning a tuple because of the `,` at the end of the declaration. this is causing an error:

```py
InvalidSchema: No connection adapters were found for "('https://api.weni.ai/v2/projects/{PROJECT_UUID}/create-wac-channel/',)"
```