### PR TITLE
Adjust the internal client to point directly to Flows

### DIFF
--- a/marketplace/connect/client.py
+++ b/marketplace/connect/client.py
@@ -55,18 +55,13 @@ class ConnectProjectClient(ConnectAuth):  # TODO: change class name to FlowsREST
     def create_wac_channel(self, user: str, project_uuid: str, phone_number_id: str, config: dict) -> dict:
         payload = {
             "user": user,
-            "project_uuid": str(project_uuid),
+            "org": str(project_uuid),
             "config": config,
             "phone_number_id": phone_number_id,
         }
-        if self.use_connect_v2:
-            del payload["project_uuid"]
-            url = self.base_url + f"/v2/projects/{project_uuid}/create-wac-channel"
-        else:
-            url = self.base_url + "/v1/organization/project/create_wac_channel/"
+        url = self._get_url("/api/v2/internals/channel/create_wac/")
 
         response = requests.post(url=url, json=payload, headers=self.auth_header(), timeout=60)
-
         return response.json()
 
     def release_channel(self, channel_uuid: str, project_uuid: str, user_email: str) -> None:

--- a/marketplace/connect/client.py
+++ b/marketplace/connect/client.py
@@ -94,8 +94,9 @@ class ConnectProjectClient(ConnectAuth):  # TODO: change class name to FlowsREST
         return response
 
     def create_external_service(self, user: str, project_uuid: str, type_fields: dict, type_code: str):
+        url = settings.CONNECT_ENGINE_BASE_URL + "/v1/externals"
         payload = {"user": user, "project": str(project_uuid), "type_fields": type_fields, "type_code": type_code}
-        response = requests.post(self._get_url("/v1/externals"), json=payload, headers=self.auth_header())
+        response = requests.post(url, json=payload, headers=self.auth_header())
         return response
 
 

--- a/marketplace/connect/client.py
+++ b/marketplace/connect/client.py
@@ -38,7 +38,12 @@ class ConnectProjectClient(ConnectAuth):  # TODO: change class name to FlowsREST
         url = self._get_url("/api/v2/internals/channel/")
 
         response = requests.get(url=url, params=params, headers=self.auth_header(), timeout=60)
-        return response.json().get("channels", None)
+
+        def map_org_to_project_uuid(channel: dict) -> dict:
+            channel["project_uuid"] = channel.pop("org")
+            return channel
+
+        return list(map(map_org_to_project_uuid, response.json()))
 
     def create_channel(self, user: str, project_uuid: str, data: dict, channeltype_code: str) -> dict:
         payload = {"user": user, "org": str(project_uuid), "data": data, "channeltype_code": channeltype_code}

--- a/marketplace/connect/client.py
+++ b/marketplace/connect/client.py
@@ -23,7 +23,7 @@ class ConnectAuth:
         return {"Authorization": self.__get_auth_token()}
 
 
-class ConnectProjectClient(ConnectAuth): # TODO: change class name to FlowsRESTClient
+class ConnectProjectClient(ConnectAuth):  # TODO: change class name to FlowsRESTClient
 
     base_url = settings.FLOWS_REST_ENDPOINT
     use_connect_v2 = settings.USE_CONNECT_V2
@@ -33,36 +33,19 @@ class ConnectProjectClient(ConnectAuth): # TODO: change class name to FlowsRESTC
         return self.base_url + endpoint
 
     def list_channels(self, channeltype_code: str) -> list:
-        params = {
-            "channel_type": channeltype_code
-        }
+        params = {"channel_type": channeltype_code}
 
         url = self._get_url("/api/v2/internals/channel/")
 
-        response = requests.get(
-            url=url,
-            params=params,
-            headers=self.auth_header(),
-            timeout=60
-        )
+        response = requests.get(url=url, params=params, headers=self.auth_header(), timeout=60)
         return response.json().get("channels", None)
 
     def create_channel(self, user: str, project_uuid: str, data: dict, channeltype_code: str) -> dict:
-        payload = {
-            "user": user,
-            "org": str(project_uuid),
-            "data": data,
-            "channeltype_code": channeltype_code
-        }
+        payload = {"user": user, "org": str(project_uuid), "data": data, "channeltype_code": channeltype_code}
 
         url = self._get_url("/api/v2/internals/channel/")
 
-        response = requests.post(
-            url=url,
-            json=payload,
-            headers=self.auth_header(),
-            timeout=60
-        )
+        response = requests.post(url=url, json=payload, headers=self.auth_header(), timeout=60)
 
         if response.status_code not in [200, 201]:
             raise ValidationError(f"{response.status_code}: {response.text}")
@@ -82,63 +65,37 @@ class ConnectProjectClient(ConnectAuth): # TODO: change class name to FlowsRESTC
         else:
             url = self.base_url + "/v1/organization/project/create_wac_channel/"
 
-        response = requests.post(
-            url=url,
-            json=payload,
-            headers=self.auth_header(),
-            timeout=60
-        )
+        response = requests.post(url=url, json=payload, headers=self.auth_header(), timeout=60)
 
         return response.json()
 
     def release_channel(self, channel_uuid: str, project_uuid: str, user_email: str) -> None:
         params = {"user": user_email}
         url = self._get_url(f"/api/v2/internals/channel/{channel_uuid}")
-        requests.delete(
-            url=url,
-            params=params,
-            headers=self.auth_header(),
-            timeout=60
-        )
+        requests.delete(url=url, params=params, headers=self.auth_header(), timeout=60)
 
         return None
 
     def get_user_api_token(self, user: str, project_uuid: str):
         params = dict(user=user, org=str(project_uuid))
         url = self._get_url("/api/v2/internals/users/api-token/")
-        response = requests.get(
-            url=url,
-            params=params,
-            headers=self.auth_header(),
-            timeout=60
-        )
+        response = requests.get(url=url, params=params, headers=self.auth_header(), timeout=60)
         return response
 
     def list_availables_channels(self):
         url = self.base_url + "/v1/channel-types"
-        response = requests.get(
-            url=url,
-            headers=self.auth_header(),
-            timeout=60
-        )
+        response = requests.get(url=url, headers=self.auth_header(), timeout=60)
         return response
 
     def detail_channel_type(self, channel_code: str):
         params = {"channel_type_code": channel_code}
         url = self.base_url + "/v1/channel-types"
-        response = requests.get(
-            url=url,
-            params=params,
-            headers=self.auth_header(),
-            timeout=60
-        )
+        response = requests.get(url=url, params=params, headers=self.auth_header(), timeout=60)
         return response
 
     def create_external_service(self, user: str, project_uuid: str, type_fields: dict, type_code: str):
         payload = {"user": user, "project": str(project_uuid), "type_fields": type_fields, "type_code": type_code}
-        response = requests.post(
-            self._get_url("/v1/externals"), json=payload, headers=self.auth_header()
-        )
+        response = requests.post(self._get_url("/v1/externals"), json=payload, headers=self.auth_header())
         return response
 
 

--- a/marketplace/connect/client.py
+++ b/marketplace/connect/client.py
@@ -72,7 +72,7 @@ class ConnectProjectClient(ConnectAuth):  # TODO: change class name to FlowsREST
         return None
 
     def get_user_api_token(self, user: str, project_uuid: str):
-        params = dict(user=user, org=str(project_uuid))
+        params = dict(user=user, project=str(project_uuid))
         url = self._get_url("/api/v2/internals/users/api-token/")
         response = requests.get(url=url, params=params, headers=self.auth_header(), timeout=60)
         return response


### PR DESCRIPTION
This PR aims to point to the client previously called Connect to Flows.

Some considerations:
The focus was on making this change and maintaining as much compatibility as possible, so the class name was not changed and some TODOs were placed in the code, thus generating technical debts.