### PR TITLE
Adds create_external_service in client of flows

### DIFF
--- a/marketplace/core/types/externals/omie/serializers.py
+++ b/marketplace/core/types/externals/omie/serializers.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 
 from marketplace.core.serializers import AppTypeBaseSerializer
 from marketplace.applications.models import App
-from marketplace.connect.client import ConnectProjectClient
+from marketplace.flows.client import FlowsClient
 
 
 class OmieSerializer(AppTypeBaseSerializer):
@@ -49,9 +49,9 @@ class ConfigSerializer(serializers.Serializer):
 
     def _create_channel(self, attrs: dict, app: App) -> str:
         user = self.context.get("request").user
-        client = ConnectProjectClient()
+        client = FlowsClient()
         return client.create_external_service(
-            user.email, app.project_uuid, attrs, app.flows_type_code
+            user.email, str(app.project_uuid), attrs, app.flows_type_code
         )
 
 

--- a/marketplace/core/types/externals/omie/tests/test_views.py
+++ b/marketplace/core/types/externals/omie/tests/test_views.py
@@ -104,16 +104,17 @@ class ConfigureOmieAppTestCase(APIBaseTestCase):
         return self.view_class.as_view({"patch": "configure"})
 
     @patch(
-        "marketplace.core.types.externals.omie.serializers.ConfigSerializer._create_channel"
+        "marketplace.core.types.externals.omie.serializers.FlowsClient.create_external_service"
     )
-    def test_configure_omie_success(self, mock_create_channel):
-        mock_response = Mock()
-        mock_response.json.return_value = {
+    def test_configure_omie_success(self, mock_create_external_service):
+        data = {
             "channelUuid": str(uuid.uuid4()),
             "title": "Teste",
         }
+        mock_response = Mock()
+        mock_response.json.return_value = data
         mock_response.status_code = 200
-        mock_create_channel.return_value = mock_response
+        mock_create_external_service.return_value = mock_response
 
         keys_values = {
             "api_key": str(uuid.uuid4()),

--- a/marketplace/flows/client.py
+++ b/marketplace/flows/client.py
@@ -54,6 +54,22 @@ class FlowsClient:
         )
         return response
 
+    def create_external_service(
+        self, user: str, project: str, type_fields: dict, type_code: str
+    ):
+        body = dict(
+            user=user, project=project, type_fields=type_fields, type_code=type_code
+        )
+        url = f"{self.base_url}/api/v2/internals/externals"
+
+        response = self.make_request(
+            url,
+            method="POST",
+            headers=self.authentication_instance.headers,
+            data=body,
+        )
+        return response
+
     def make_request(self, url: str, method: str, headers=None, data=None, params=None):
         try:
             response = requests.request(
@@ -74,7 +90,7 @@ class FlowsClient:
         except requests.exceptions.RequestException as exception:
             # Handle general network exceptions
             raise APIException(
-                detail=f"RequestException: {str(exception)}", code=response.status_code
+                detail=f"RequestException: {str(exception)}", code=500
             ) from exception
 
         return response


### PR DESCRIPTION
- This change adds the create_external_service method in the flows client.
- Small fix in make_request method to display request errors when the server does not respond.