### PR TITLE
Configure flake8 to ignore F401 error in __init__.py files

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,7 @@
 [flake8]
+per-file-ignores =
+    */__init__.py:F401
+
 exclude = 
     .git,
     __pycache__,


### PR DESCRIPTION
It is common to use `__init__.py ` to import classes from the package itself, thus creating a kind of facade that facilitates imports and encapsulates the package itself. However, flake8 identifies that the import is not being used and therefore considers it an error, this PR aims to solve this problem.