### PR TITLE
Create TemplateType and Project consumers and handle queues

### DIFF
--- a/marketplace/applications/usecases/__init__.py
+++ b/marketplace/applications/usecases/__init__.py
@@ -1,0 +1,1 @@
+from .app_configuration import AppConfigurationUseCase

--- a/marketplace/applications/usecases/app_configuration.py
+++ b/marketplace/applications/usecases/app_configuration.py
@@ -1,0 +1,19 @@
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:  # pragma: no cover
+    from django.contrib.auth import get_user_model
+
+    from marketplace.core.types import AppType
+    from ..models import App
+
+    User = get_user_model()
+
+
+class AppConfigurationUseCase:  # pragma: no cover
+    def __init__(self, channel_client, channel_token_client):
+        self.__channel_client = channel_client
+        self.__channel_token_client = channel_token_client
+
+    def configure_app(self, app: "App", apptype: "AppType", user: "User") -> None:
+        apptype.configure_app(app, user, self.__channel_client, self.__channel_token_client)

--- a/marketplace/event_driven/consumers.py
+++ b/marketplace/event_driven/consumers.py
@@ -6,7 +6,6 @@ from .signals import message_started, message_finished
 
 
 class EDAConsumer(ABC):
-
     def handle(self, message: amqp.Message):
         message_started.send(sender=self)
         try:

--- a/marketplace/event_driven/consumers.py
+++ b/marketplace/event_driven/consumers.py
@@ -5,7 +5,7 @@ import amqp
 from .signals import message_started, message_finished
 
 
-class EDAConsumer(ABC):
+class EDAConsumer(ABC):  # pragma: no cover
     def handle(self, message: amqp.Message):
         message_started.send(sender=self)
         try:

--- a/marketplace/event_driven/handle.py
+++ b/marketplace/event_driven/handle.py
@@ -1,5 +1,8 @@
 from amqp.channel import Channel
 
+from .consumers import TemplateTypeConsumer, ProjectConsumer
+
 
 def handle_consumers(channel: Channel) -> None:
-    pass
+    channel.basic_consume("integrations.template-types", callback=TemplateTypeConsumer.consume)
+    channel.basic_consume("integrations.projects", callback=ProjectConsumer.consume)

--- a/marketplace/event_driven/handle.py
+++ b/marketplace/event_driven/handle.py
@@ -1,8 +1,7 @@
 from amqp.channel import Channel
 
-from .consumers import TemplateTypeConsumer, ProjectConsumer
+from marketplace.projects.handle import handle_consumers as project_handle_consumers
 
 
 def handle_consumers(channel: Channel) -> None:
-    channel.basic_consume("integrations.template-types", callback=TemplateTypeConsumer.consume)
-    channel.basic_consume("integrations.projects", callback=ProjectConsumer.consume)
+    project_handle_consumers(channel)

--- a/marketplace/projects/consumers/__init__.py
+++ b/marketplace/projects/consumers/__init__.py
@@ -1,0 +1,1 @@
+from .template_type_consumer import TemplateTypeConsumer

--- a/marketplace/projects/consumers/__init__.py
+++ b/marketplace/projects/consumers/__init__.py
@@ -1,1 +1,2 @@
+from .project_consumer import ProjectConsumer
 from .template_type_consumer import TemplateTypeConsumer

--- a/marketplace/projects/consumers/project_consumer.py
+++ b/marketplace/projects/consumers/project_consumer.py
@@ -5,11 +5,11 @@ from ..usecases import TemplateTypeIntegrationUseCase, ProjectCreationUseCase, A
 from ..usecases.exceptions import InvalidProjectData, InvalidTemplateTypeData
 from marketplace.connect.client import ConnectProjectClient, WPPRouterChannelClient
 from marketplace.event_driven.parsers import JSONParser, ParseError
+from marketplace.event_driven.consumers import EDAConsumer
 
 
-class ProjectConsumer:
-    @staticmethod
-    def consume(message: amqp.Message):
+class ProjectConsumer(EDAConsumer):
+    def consume(self, message: amqp.Message):
         print(f"[ProjectConsumer] - Consuming a message. Body: {message.body}")
 
         try:

--- a/marketplace/projects/consumers/project_consumer.py
+++ b/marketplace/projects/consumers/project_consumer.py
@@ -1,6 +1,6 @@
 import amqp
 
-from ..usecases import ProjectCreationUseCase, AppSetupHandlerUseCase, ProjectCreationDTO
+from ..usecases import TemplateTypeIntegrationUseCase, ProjectCreationUseCase, AppSetupHandlerUseCase, ProjectCreationDTO
 from marketplace.connect.client import ConnectProjectClient, WPPRouterChannelClient
 from marketplace.event_driven.parsers import JSONParser
 
@@ -15,7 +15,6 @@ class ProjectConsumer:
             uuid=body.get("uuid"),
             name=body.get("name"),
             is_template=body.get("is_template"),
-            user_email=body.get("user_email"),
             date_format=body.get("date_format"),
             template_type_uuid=body.get("template_type_uuid"),
             timezone=body.get("timezone"),
@@ -25,8 +24,9 @@ class ProjectConsumer:
         wpp_router_client = WPPRouterChannelClient()
 
         app_setup_handler = AppSetupHandlerUseCase(connect_client, wpp_router_client)
+        template_type_integration = TemplateTypeIntegrationUseCase(app_setup_handler)
 
-        project_creation = ProjectCreationUseCase(app_setup_handler)
-        project_creation.create_project(project_dto)
+        project_creation = ProjectCreationUseCase(template_type_integration)
+        project_creation.create_project(project_dto, body.get("user_email"))
 
         message.channel.basic_ack(message.delivery_tag)

--- a/marketplace/projects/consumers/project_consumer.py
+++ b/marketplace/projects/consumers/project_consumer.py
@@ -1,14 +1,18 @@
 import amqp
 from sentry_sdk import capture_exception
 
-from ..usecases import TemplateTypeIntegrationUseCase, ProjectCreationUseCase, AppSetupHandlerUseCase, ProjectCreationDTO
-from ..usecases.exceptions import InvalidProjectData, InvalidTemplateTypeData
+from ..usecases import (
+    TemplateTypeIntegrationUseCase,
+    ProjectCreationUseCase,
+    AppSetupHandlerUseCase,
+    ProjectCreationDTO,
+)
 from marketplace.connect.client import ConnectProjectClient, WPPRouterChannelClient
-from marketplace.event_driven.parsers import JSONParser, ParseError
+from marketplace.event_driven.parsers import JSONParser
 from marketplace.event_driven.consumers import EDAConsumer
 
 
-class ProjectConsumer(EDAConsumer):
+class ProjectConsumer(EDAConsumer):  # pragma: no cover
     def consume(self, message: amqp.Message):
         print(f"[ProjectConsumer] - Consuming a message. Body: {message.body}")
 

--- a/marketplace/projects/consumers/project_consumer.py
+++ b/marketplace/projects/consumers/project_consumer.py
@@ -1,0 +1,32 @@
+import amqp
+
+from ..usecases import ProjectCreationUseCase, AppSetupHandlerUseCase, ProjectCreationDTO
+from marketplace.connect.client import ConnectProjectClient, WPPRouterChannelClient
+from marketplace.event_driven.parsers import JSONParser
+
+
+class ProjectConsumer:
+    @staticmethod
+    def consume(message: amqp.Message):
+        body = JSONParser.parse(message.body)
+        print(f"[ProjectConsumer] - Consuming a message. Body: {body}")
+
+        project_dto = ProjectCreationDTO(
+            uuid=body.get("uuid"),
+            name=body.get("name"),
+            is_template=body.get("is_template"),
+            user_email=body.get("user_email"),
+            date_format=body.get("date_format"),
+            template_type_uuid=body.get("template_type_uuid"),
+            timezone=body.get("timezone"),
+        )
+
+        connect_client = ConnectProjectClient()
+        wpp_router_client = WPPRouterChannelClient()
+
+        app_setup_handler = AppSetupHandlerUseCase(connect_client, wpp_router_client)
+
+        project_creation = ProjectCreationUseCase(app_setup_handler)
+        project_creation.create_project(project_dto)
+
+        message.channel.basic_ack(message.delivery_tag)

--- a/marketplace/projects/consumers/project_consumer.py
+++ b/marketplace/projects/consumers/project_consumer.py
@@ -7,6 +7,7 @@ from ..usecases import (
     AppSetupHandlerUseCase,
     ProjectCreationDTO,
 )
+from marketplace.applications.usecases import AppConfigurationUseCase
 from marketplace.connect.client import ConnectProjectClient, WPPRouterChannelClient
 from marketplace.event_driven.parsers import JSONParser
 from marketplace.event_driven.consumers import EDAConsumer
@@ -30,8 +31,9 @@ class ProjectConsumer(EDAConsumer):  # pragma: no cover
 
             connect_client = ConnectProjectClient()
             wpp_router_client = WPPRouterChannelClient()
+            app_configuration = AppConfigurationUseCase(connect_client, wpp_router_client)
 
-            app_setup_handler = AppSetupHandlerUseCase(connect_client, wpp_router_client)
+            app_setup_handler = AppSetupHandlerUseCase(app_configuration)
             template_type_integration = TemplateTypeIntegrationUseCase(app_setup_handler)
 
             project_creation = ProjectCreationUseCase(template_type_integration)

--- a/marketplace/projects/consumers/project_consumer.py
+++ b/marketplace/projects/consumers/project_consumer.py
@@ -33,10 +33,9 @@ class ProjectConsumer(EDAConsumer):
             project_creation = ProjectCreationUseCase(template_type_integration)
             project_creation.create_project(project_dto, body.get("user_email"))
 
+            message.channel.basic_ack(message.delivery_tag)
+
         except Exception as exception:
             capture_exception(exception)
             message.channel.basic_reject(message.delivery_tag, requeue=False)
             print(f"[ProjectConsumer] - Message rejected by: {exception}")
-            return None
-
-        message.channel.basic_ack(message.delivery_tag)

--- a/marketplace/projects/consumers/project_consumer.py
+++ b/marketplace/projects/consumers/project_consumer.py
@@ -1,32 +1,42 @@
 import amqp
+from sentry_sdk import capture_exception
 
 from ..usecases import TemplateTypeIntegrationUseCase, ProjectCreationUseCase, AppSetupHandlerUseCase, ProjectCreationDTO
+from ..usecases.exceptions import InvalidProjectData, InvalidTemplateTypeData
 from marketplace.connect.client import ConnectProjectClient, WPPRouterChannelClient
-from marketplace.event_driven.parsers import JSONParser
+from marketplace.event_driven.parsers import JSONParser, ParseError
 
 
 class ProjectConsumer:
     @staticmethod
     def consume(message: amqp.Message):
-        body = JSONParser.parse(message.body)
-        print(f"[ProjectConsumer] - Consuming a message. Body: {body}")
+        print(f"[ProjectConsumer] - Consuming a message. Body: {message.body}")
 
-        project_dto = ProjectCreationDTO(
-            uuid=body.get("uuid"),
-            name=body.get("name"),
-            is_template=body.get("is_template"),
-            date_format=body.get("date_format"),
-            template_type_uuid=body.get("template_type_uuid"),
-            timezone=body.get("timezone"),
-        )
+        try:
+            body = JSONParser.parse(message.body)
 
-        connect_client = ConnectProjectClient()
-        wpp_router_client = WPPRouterChannelClient()
+            project_dto = ProjectCreationDTO(
+                uuid=body.get("uuid"),
+                name=body.get("name"),
+                is_template=body.get("is_template"),
+                date_format=body.get("date_format"),
+                template_type_uuid=body.get("template_type_uuid"),
+                timezone=body.get("timezone"),
+            )
 
-        app_setup_handler = AppSetupHandlerUseCase(connect_client, wpp_router_client)
-        template_type_integration = TemplateTypeIntegrationUseCase(app_setup_handler)
+            connect_client = ConnectProjectClient()
+            wpp_router_client = WPPRouterChannelClient()
 
-        project_creation = ProjectCreationUseCase(template_type_integration)
-        project_creation.create_project(project_dto, body.get("user_email"))
+            app_setup_handler = AppSetupHandlerUseCase(connect_client, wpp_router_client)
+            template_type_integration = TemplateTypeIntegrationUseCase(app_setup_handler)
+
+            project_creation = ProjectCreationUseCase(template_type_integration)
+            project_creation.create_project(project_dto, body.get("user_email"))
+
+        except Exception as exception:
+            capture_exception(exception)
+            message.channel.basic_reject(message.delivery_tag, requeue=False)
+            print(f"[ProjectConsumer] - Message rejected by: {exception}")
+            return None
 
         message.channel.basic_ack(message.delivery_tag)

--- a/marketplace/projects/consumers/template_type_consumer.py
+++ b/marketplace/projects/consumers/template_type_consumer.py
@@ -1,12 +1,12 @@
 import amqp
 
 from marketplace.event_driven.parsers import JSONParser
+from marketplace.event_driven.consumers import EDAConsumer
 from ..usecases import create_template_type
 
 
-class TemplateTypeConsumer:
-    @staticmethod
-    def consume(message: amqp.Message):
+class TemplateTypeConsumer(EDAConsumer):
+    def consume(self, message: amqp.Message):
         body = JSONParser.parse(message.body)
 
         print(f"[TemplateTypeConsumer] - Consuming a message. Body: {body}")

--- a/marketplace/projects/consumers/template_type_consumer.py
+++ b/marketplace/projects/consumers/template_type_consumer.py
@@ -5,7 +5,7 @@ from marketplace.event_driven.consumers import EDAConsumer
 from ..usecases import create_template_type
 
 
-class TemplateTypeConsumer(EDAConsumer):
+class TemplateTypeConsumer(EDAConsumer):  # pragma: no cover
     def consume(self, message: amqp.Message):
         body = JSONParser.parse(message.body)
 

--- a/marketplace/projects/consumers/template_type_consumer.py
+++ b/marketplace/projects/consumers/template_type_consumer.py
@@ -1,0 +1,16 @@
+import amqp
+
+from marketplace.event_driven.parsers import JSONParser
+from ..usecases import create_template_type
+
+
+class TemplateTypeConsumer:
+    @staticmethod
+    def consume(message: amqp.Message):
+        body = JSONParser.parse(message.body)
+
+        print(f"[TemplateTypeConsumer] - Consuming a message. Body: {body}")
+
+        create_template_type(uuid=body.get("uuid"), project_uuid=body.get("project_uuid"), name=body.get("name"))
+
+        message.channel.basic_ack(message.delivery_tag)

--- a/marketplace/projects/handle.py
+++ b/marketplace/projects/handle.py
@@ -4,5 +4,5 @@ from .consumers import TemplateTypeConsumer, ProjectConsumer
 
 
 def handle_consumers(channel: Channel) -> None:
-    channel.basic_consume("integrations.template-types", callback=TemplateTypeConsumer.consume)
-    channel.basic_consume("integrations.projects", callback=ProjectConsumer.consume)
+    channel.basic_consume("integrations.template-types", callback=TemplateTypeConsumer().handle)
+    channel.basic_consume("integrations.projects", callback=ProjectConsumer().handle)

--- a/marketplace/projects/handle.py
+++ b/marketplace/projects/handle.py
@@ -1,0 +1,7 @@
+from amqp.channel import Channel
+
+from .consumers import TemplateTypeConsumer
+
+
+def handle_consumers(channel: Channel) -> None:
+    channel.basic_consume("integrations.template-types", callback=TemplateTypeConsumer.consume)

--- a/marketplace/projects/handle.py
+++ b/marketplace/projects/handle.py
@@ -1,7 +1,8 @@
 from amqp.channel import Channel
 
-from .consumers import TemplateTypeConsumer
+from .consumers import TemplateTypeConsumer, ProjectConsumer
 
 
 def handle_consumers(channel: Channel) -> None:
     channel.basic_consume("integrations.template-types", callback=TemplateTypeConsumer.consume)
+    channel.basic_consume("integrations.projects", callback=ProjectConsumer.consume)

--- a/marketplace/projects/usecases/__init__.py
+++ b/marketplace/projects/usecases/__init__.py
@@ -1,1 +1,2 @@
 from .template_type_creation import create_template_type
+from .app_setup_handler import AppSetupHandlerUseCase

--- a/marketplace/projects/usecases/__init__.py
+++ b/marketplace/projects/usecases/__init__.py
@@ -1,0 +1,1 @@
+from .template_type_creation import create_template_type

--- a/marketplace/projects/usecases/__init__.py
+++ b/marketplace/projects/usecases/__init__.py
@@ -2,3 +2,4 @@ from .exceptions import InvalidProjectData
 from .template_type_creation import create_template_type
 from .project_creation import ProjectCreationUseCase, ProjectCreationDTO
 from .app_setup_handler import AppSetupHandlerUseCase
+from .template_type_integration import TemplateTypeIntegrationUseCase

--- a/marketplace/projects/usecases/__init__.py
+++ b/marketplace/projects/usecases/__init__.py
@@ -1,2 +1,4 @@
+from .exceptions import InvalidProjectData
 from .template_type_creation import create_template_type
+from .project_creation import ProjectCreationUseCase, ProjectCreationDTO
 from .app_setup_handler import AppSetupHandlerUseCase

--- a/marketplace/projects/usecases/app_setup_handler.py
+++ b/marketplace/projects/usecases/app_setup_handler.py
@@ -1,0 +1,34 @@
+from django.contrib.auth import get_user_model
+
+from ..models import Project, TemplateType
+from .exceptions import InvalidTemplateTypeData
+from marketplace.core.types import APPTYPES
+
+
+User = get_user_model()
+
+
+class AppSetupHandlerUseCase:
+    def __init__(self, channel_client, channel_token_client):
+        self.__channel_client = channel_client
+        self.__channel_token_client = channel_token_client
+
+    def setup_apps_in_project(self, project: Project, template_type: TemplateType, user: User):
+        setup = template_type.setup
+
+        if setup == {}:
+            raise InvalidTemplateTypeData(f"The `setup` of TemplateType {template_type.uuid} is empty!")
+
+        for setup_app in setup.get("apps"):
+            code = setup_app.get("code")
+
+            if not code:
+                raise InvalidTemplateTypeData(f"The TemplateType {template_type.uuid} has an invalid setup!")
+
+            try:
+                apptype = APPTYPES.get(code)
+            except KeyError:
+                raise InvalidTemplateTypeData(f"TemplateType {template_type.uuid} has invalid app code!")
+
+            app = apptype.create_app(project_uuid=str(project.uuid), created_by=user)
+            apptype.configure_app(app, user, self.__channel_client, self.__channel_token_client)

--- a/marketplace/projects/usecases/app_setup_handler.py
+++ b/marketplace/projects/usecases/app_setup_handler.py
@@ -9,9 +9,8 @@ User = get_user_model()
 
 
 class AppSetupHandlerUseCase:
-    def __init__(self, channel_client, channel_token_client):
-        self.__channel_client = channel_client
-        self.__channel_token_client = channel_token_client
+    def __init__(self, app_configuration):
+        self.__app_configuration = app_configuration
 
     def setup_apps_in_project(self, project: Project, template_type: TemplateType, user: User):
         setup = template_type.setup
@@ -31,4 +30,4 @@ class AppSetupHandlerUseCase:
                 raise InvalidTemplateTypeData(f"TemplateType {template_type.uuid} has invalid app code!")
 
             app = apptype.create_app(project_uuid=str(project.uuid), created_by=user)
-            apptype.configure_app(app, user, self.__channel_client, self.__channel_token_client)
+            self.__app_configuration.configure_app(app, apptype, user)

--- a/marketplace/projects/usecases/exceptions.py
+++ b/marketplace/projects/usecases/exceptions.py
@@ -1,5 +1,6 @@
 class InvalidProjectData(Exception):
     pass
 
+
 class InvalidTemplateTypeData(Exception):
     pass

--- a/marketplace/projects/usecases/exceptions.py
+++ b/marketplace/projects/usecases/exceptions.py
@@ -1,2 +1,5 @@
+class InvalidProjectData(Exception):
+    pass
+
 class InvalidTemplateTypeData(Exception):
     pass

--- a/marketplace/projects/usecases/exceptions.py
+++ b/marketplace/projects/usecases/exceptions.py
@@ -1,0 +1,2 @@
+class InvalidTemplateTypeData(Exception):
+    pass

--- a/marketplace/projects/usecases/interfaces.py
+++ b/marketplace/projects/usecases/interfaces.py
@@ -1,0 +1,15 @@
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from django.contrib.auth import get_user_model
+
+    from ..models import Project
+
+    User = get_user_model()
+
+
+class TemplateTypeIntegrationInterface(ABC):
+    @abstractmethod
+    def integrate_template_type_in_project(self, project: "Project", template_type_uuid: str, user: "User"):
+        pass

--- a/marketplace/projects/usecases/interfaces.py
+++ b/marketplace/projects/usecases/interfaces.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from django.contrib.auth import get_user_model
 
     from ..models import Project
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     User = get_user_model()
 
 
-class TemplateTypeIntegrationInterface(ABC):
+class TemplateTypeIntegrationInterface(ABC):  # pragma: no cover
     @abstractmethod
     def integrate_template_type_in_project(self, project: "Project", template_type_uuid: str, user: "User"):
         pass

--- a/marketplace/projects/usecases/project_creation.py
+++ b/marketplace/projects/usecases/project_creation.py
@@ -3,7 +3,6 @@ from django.contrib.auth import get_user_model
 
 from ..models import Project
 from .interfaces import TemplateTypeIntegrationInterface
-from .exceptions import InvalidProjectData
 
 
 User = get_user_model()
@@ -23,11 +22,8 @@ class ProjectCreationUseCase:
     def __init__(self, template_type_integration: TemplateTypeIntegrationInterface):
         self.__template_type_integration = template_type_integration
 
-    def get_user_by_email(self, email: str) -> User:
-        try:
-            return User.objects.get(email=email)
-        except User.DoesNotExist:
-            raise InvalidProjectData(f"User with email `{email}` does not exist!")
+    def get_or_create_user_by_email(self, email: str) -> tuple:
+        return User.objects.get_or_create(email=email)
 
     def get_or_create_project(self, project_dto: ProjectCreationDTO, user: User) -> tuple:
         return Project.objects.get_or_create(
@@ -42,7 +38,7 @@ class ProjectCreationUseCase:
         )
 
     def create_project(self, project_dto: ProjectCreationDTO, user_email: str) -> None:
-        user = self.get_user_by_email(user_email)
+        user, _ = self.get_or_create_user_by_email(user_email)
         project, _ = self.get_or_create_project(project_dto, user)
 
         if project_dto.is_template:

--- a/marketplace/projects/usecases/project_creation.py
+++ b/marketplace/projects/usecases/project_creation.py
@@ -29,7 +29,7 @@ class ProjectCreationUseCase:
         except User.DoesNotExist:
             raise InvalidProjectData(f"User with email `{email}` does not exist!")
 
-    def get_or_create_project(self, project_dto: ProjectCreationDTO, user: User) -> tuple[Project, bool]:
+    def get_or_create_project(self, project_dto: ProjectCreationDTO, user: User) -> tuple:
         return Project.objects.get_or_create(
             uuid=project_dto.uuid,
             defaults=dict(

--- a/marketplace/projects/usecases/project_creation.py
+++ b/marketplace/projects/usecases/project_creation.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
-
 from django.contrib.auth import get_user_model
 
-from ..models import Project, TemplateType
+from ..models import Project
+from .interfaces import TemplateTypeIntegrationInterface
 from .exceptions import InvalidProjectData
 
 
@@ -14,51 +14,38 @@ class ProjectCreationDTO:
     uuid: str
     name: str
     is_template: bool
-    user_email: str
     date_format: str
     timezone: str
     template_type_uuid: str
 
 
 class ProjectCreationUseCase:
-    def __init__(self, app_setup_handler):
-        self.__app_setup_handler = app_setup_handler
+    def __init__(self, template_type_integration: TemplateTypeIntegrationInterface):
+        self.__template_type_integration = template_type_integration
 
-    def create_project(self, project_dto: ProjectCreationDTO):
-        project: Project = None
-        template_type: TemplateType = None
-        user: User = None
-
-        if project_dto.is_template and project_dto.template_type_uuid is None:
-            raise InvalidProjectData("'template_type_uuid' cannot be empty when 'is_template' is True!")
-
+    def get_user_by_email(self, email: str) -> User:
         try:
-            template_type = TemplateType.objects.get(uuid=project_dto.template_type_uuid)
-        except TemplateType.DoesNotExist:
-            raise InvalidProjectData(f"Template Type with uuid `{project_dto.template_type_uuid}` does not exists!")
-
-        try:
-            user = User.objects.get(email=project_dto.user_email)
+            return User.objects.get(email=email)
         except User.DoesNotExist:
-            raise InvalidProjectData(f"User with email `{project_dto.user_email}` does not exist!")
+            raise InvalidProjectData(f"User with email `{email}` does not exist!")
 
-        project = Project.objects.filter(uuid=project_dto.uuid).first()
-
-        if project:
-            if project_dto.is_template and project.template_type is not None:
-                raise InvalidProjectData(f"The project `{project.uuid}` already has an integrated template!")
-
-        else:
-            project = Project.objects.create(
-                uuid=project_dto.uuid,
+    def get_or_create_project(self, project_dto: ProjectCreationDTO, user: User) -> tuple[Project, bool]:
+        return Project.objects.get_or_create(
+            uuid=project_dto.uuid,
+            defaults=dict(
                 name=project_dto.name,
-                is_template=project_dto.is_template,
                 date_format=project_dto.date_format,
                 timezone=project_dto.timezone,
                 created_by=user,
-            )
+                is_template=project_dto.is_template,
+            ),
+        )
+
+    def create_project(self, project_dto: ProjectCreationDTO, user_email: str) -> None:
+        user = self.get_user_by_email(user_email)
+        project, _ = self.get_or_create_project(project_dto, user)
 
         if project_dto.is_template:
-            self.__app_setup_handler.setup_apps_in_project(project, template_type, user)
-            project.template_type = template_type
-            project.save()
+            self.__template_type_integration.integrate_template_type_in_project(
+                project, project_dto.template_type_uuid, user
+            )

--- a/marketplace/projects/usecases/project_creation.py
+++ b/marketplace/projects/usecases/project_creation.py
@@ -1,0 +1,64 @@
+from dataclasses import dataclass
+
+from django.contrib.auth import get_user_model
+
+from ..models import Project, TemplateType
+from .exceptions import InvalidProjectData
+
+
+User = get_user_model()
+
+
+@dataclass
+class ProjectCreationDTO:
+    uuid: str
+    name: str
+    is_template: bool
+    user_email: str
+    date_format: str
+    timezone: str
+    template_type_uuid: str
+
+
+class ProjectCreationUseCase:
+    def __init__(self, app_setup_handler):
+        self.__app_setup_handler = app_setup_handler
+
+    def create_project(self, project_dto: ProjectCreationDTO):
+        project: Project = None
+        template_type: TemplateType = None
+        user: User = None
+
+        if project_dto.is_template and project_dto.template_type_uuid is None:
+            raise InvalidProjectData("'template_type_uuid' cannot be empty when 'is_template' is True!")
+
+        try:
+            template_type = TemplateType.objects.get(uuid=project_dto.template_type_uuid)
+        except TemplateType.DoesNotExist:
+            raise InvalidProjectData(f"Template Type with uuid `{project_dto.template_type_uuid}` does not exists!")
+
+        try:
+            user = User.objects.get(email=project_dto.user_email)
+        except User.DoesNotExist:
+            raise InvalidProjectData(f"User with email `{project_dto.user_email}` does not exist!")
+
+        project = Project.objects.filter(uuid=project_dto.uuid).first()
+
+        if project:
+            if project_dto.is_template and project.template_type is not None:
+                raise InvalidProjectData(f"The project `{project.uuid}` already has an integrated template!")
+
+        else:
+            project = Project.objects.create(
+                uuid=project_dto.uuid,
+                name=project_dto.name,
+                is_template=project_dto.is_template,
+                date_format=project_dto.date_format,
+                timezone=project_dto.timezone,
+                created_by=user,
+            )
+
+        if project_dto.is_template:
+            self.__app_setup_handler.setup_apps_in_project(project, template_type, user)
+            project.template_type = template_type
+            project.save()

--- a/marketplace/projects/usecases/template_type_creation.py
+++ b/marketplace/projects/usecases/template_type_creation.py
@@ -10,7 +10,6 @@ def create_template_type(uuid: str, project_uuid: Project, name: str) -> Templat
             setup["apps"].append(app.apptype.template_type_setup())
         except NotImplementedError as error:
             print(error)
-            # TODO: handle error
             pass
 
     template_type, created = TemplateType.objects.get_or_create(uuid=uuid, defaults=dict(name=name, setup=setup))

--- a/marketplace/projects/usecases/template_type_creation.py
+++ b/marketplace/projects/usecases/template_type_creation.py
@@ -6,7 +6,12 @@ def create_template_type(uuid: str, project_uuid: Project, name: str) -> Templat
     setup = {"apps": []}
 
     for app in App.objects.filter(project_uuid=project_uuid):
-        setup["apps"].append(app.apptype.template_type_setup())
+        try:
+            setup["apps"].append(app.apptype.template_type_setup())
+        except NotImplementedError as error:
+            print(error)
+            # TODO: handle error
+            pass
 
     template_type, created = TemplateType.objects.get_or_create(uuid=uuid, defaults=dict(name=name, setup=setup))
 

--- a/marketplace/projects/usecases/template_type_creation.py
+++ b/marketplace/projects/usecases/template_type_creation.py
@@ -1,0 +1,18 @@
+from marketplace.applications.models import App
+from ..models import TemplateType, Project
+
+
+def create_template_type(uuid: str, project_uuid: Project, name: str) -> TemplateType:
+    setup = {"apps": []}
+
+    for app in App.objects.filter(project_uuid=project_uuid):
+        setup["apps"].append(app.apptype.template_type_setup())
+
+    template_type, created = TemplateType.objects.get_or_create(uuid=uuid, defaults=dict(name=name, setup=setup))
+
+    if not created:
+        template_type.name = name
+        template_type.setup = setup
+        template_type.save()
+
+    return template_type

--- a/marketplace/projects/usecases/template_type_integration.py
+++ b/marketplace/projects/usecases/template_type_integration.py
@@ -1,0 +1,33 @@
+from typing import TYPE_CHECKING
+
+from .interfaces import TemplateTypeIntegrationInterface
+from .exceptions import InvalidTemplateTypeData
+from ..models import TemplateType
+
+
+if TYPE_CHECKING:
+    from ..models import Project
+    from django.contrib.auth import get_user_model
+
+    User = get_user_model()
+
+
+class TemplateTypeIntegrationUseCase(TemplateTypeIntegrationInterface):
+    def __init__(self, app_setup_handler):
+        self.__app_setup_handler = app_setup_handler
+
+    def integrate_template_type_in_project(self, project: "Project", template_type_uuid: str, user: "User") -> None:
+        if project.template_type is not None:
+            raise InvalidTemplateTypeData(f"The project `{project.uuid}` already has an integrated template!")
+
+        if template_type_uuid is None:
+            raise InvalidTemplateTypeData("'template_type_uuid' cannot be empty when 'is_template' is True!")
+
+        try:
+            template_type = TemplateType.objects.get(uuid=template_type_uuid)
+        except TemplateType.DoesNotExist:
+            raise InvalidTemplateTypeData(f"Template Type with uuid `{template_type_uuid}` does not exists!")
+
+        self.__app_setup_handler.setup_apps_in_project(project, template_type, user)
+        project.template_type = template_type
+        project.save()

--- a/marketplace/projects/usecases/template_type_integration.py
+++ b/marketplace/projects/usecases/template_type_integration.py
@@ -5,7 +5,7 @@ from .exceptions import InvalidTemplateTypeData
 from ..models import TemplateType
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from ..models import Project
     from django.contrib.auth import get_user_model
 

--- a/marketplace/projects/usecases/tests/test_app_setup_handler.py
+++ b/marketplace/projects/usecases/tests/test_app_setup_handler.py
@@ -1,0 +1,52 @@
+import uuid
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+
+from ..app_setup_handler import AppSetupHandlerUseCase
+from ...models import Project, TemplateType
+from ..exceptions import InvalidTemplateTypeData
+
+
+User = get_user_model()
+
+
+class AppSetupHandlerTestCase(TestCase):
+    def setUp(self):
+        self.app_configuration = MagicMock()
+        self.uescase = AppSetupHandlerUseCase(self.app_configuration)
+
+        self.user = User.objects.create_superuser(email="user@marketplace.ai")
+        self.project = Project.objects.create(uuid=uuid.uuid4(), name="Test Project", created_by=self.user)
+
+    def test_empty_setup_raises_invalid_template_type_data(self):
+        template_type = TemplateType.objects.create(uuid=uuid.uuid4(), name="Fake TT", setup={})
+
+        error_message = f"The `setup` of TemplateType {template_type.uuid} is empty!"
+        with self.assertRaisesMessage(InvalidTemplateTypeData, error_message):
+            self.uescase.setup_apps_in_project(self.project, template_type, self.user)
+
+    def test_setup_without_code_raises_invalid_template_type_data(self):
+        template_type = TemplateType.objects.create(uuid=uuid.uuid4(), name="Fake TT", setup={"apps": [{}]})
+
+        error_message = f"The TemplateType {template_type.uuid} has an invalid setup!"
+        with self.assertRaisesMessage(InvalidTemplateTypeData, error_message):
+            self.uescase.setup_apps_in_project(self.project, template_type, self.user)
+
+    def test_setup_without_invalid_code_raises_invalid_template_type_data(self):
+        template_type = TemplateType.objects.create(
+            uuid=uuid.uuid4(), name="Fake TT", setup={"apps": [{"code": "fake-code"}]}
+        )
+
+        error_message = f"TemplateType {template_type.uuid} has invalid app code!"
+        with self.assertRaisesMessage(InvalidTemplateTypeData, error_message):
+            self.uescase.setup_apps_in_project(self.project, template_type, self.user)
+
+    def test_configure_app_called_once_with_valid_template_type(self):
+        template_type = TemplateType.objects.create(
+            uuid=uuid.uuid4(), name="Fake TT", setup={"apps": [{"code": "wpp-demo"}]}
+        )
+
+        self.uescase.setup_apps_in_project(self.project, template_type, self.user)
+        self.app_configuration.configure_app.assert_called_once()

--- a/marketplace/projects/usecases/tests/test_project_creation.py
+++ b/marketplace/projects/usecases/tests/test_project_creation.py
@@ -6,7 +6,6 @@ from django.contrib.auth import get_user_model
 
 from ...models import Project
 from ..project_creation import ProjectCreationDTO, ProjectCreationUseCase
-from ..exceptions import InvalidProjectData
 
 
 User = get_user_model()
@@ -18,17 +17,18 @@ class ProjectCreationTestCase(TestCase):
         self.user = User.objects.create_superuser(email="user@marketplace.ai")
         self.project = Project.objects.create(uuid=uuid.uuid4(), name="Test Project", created_by=self.user)
 
-    def test_get_user_by_email_raises_invalid_project_data(self):
+    def test_get_or_create_user_by_email(self):
         usecase = ProjectCreationUseCase(self.template_type_integration)
-
-        with self.assertRaisesMessage(InvalidProjectData, "User with email `fake@email.com` does not exist!"):
-            usecase.get_user_by_email("fake@email.com")
-
-    def test_get_user_by_email(self):
-        usecase = ProjectCreationUseCase(self.template_type_integration)
-        user = usecase.get_user_by_email("user@marketplace.ai")
+        user, _ = usecase.get_or_create_user_by_email("user@marketplace.ai")
 
         self.assertEqual(user, self.user)
+
+    def test_get_or_create_user_by_email_creates_new_user(self):
+        new_user_email = "newuser@marketplace.ai"
+        usecase = ProjectCreationUseCase(self.template_type_integration)
+        user, _ = usecase.get_or_create_user_by_email(new_user_email)
+
+        self.assertEqual(user.email, new_user_email)
 
     def test_creating_template_project_integrate_template_type_in_project_is_called(self):
         project_uuid = uuid.uuid4()

--- a/marketplace/projects/usecases/tests/test_project_creation.py
+++ b/marketplace/projects/usecases/tests/test_project_creation.py
@@ -21,7 +21,7 @@ class ProjectCreationTestCase(TestCase):
     def test_get_user_by_email_raises_invalid_project_data(self):
         usecase = ProjectCreationUseCase(self.template_type_integration)
 
-        with self.assertRaisesMessage(InvalidProjectData, f"User with email `fake@email.com` does not exist!"):
+        with self.assertRaisesMessage(InvalidProjectData, "User with email `fake@email.com` does not exist!"):
             usecase.get_user_by_email("fake@email.com")
 
     def test_get_user_by_email(self):

--- a/marketplace/projects/usecases/tests/test_project_creation.py
+++ b/marketplace/projects/usecases/tests/test_project_creation.py
@@ -1,0 +1,94 @@
+import uuid
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+
+from ...models import Project
+from ..project_creation import ProjectCreationDTO, ProjectCreationUseCase
+from ..exceptions import InvalidProjectData
+
+
+User = get_user_model()
+
+
+class ProjectCreationTestCase(TestCase):
+    def setUp(self) -> None:
+        self.template_type_integration = MagicMock()
+        self.user = User.objects.create_superuser(email="user@marketplace.ai")
+        self.project = Project.objects.create(uuid=uuid.uuid4(), name="Test Project", created_by=self.user)
+
+    def test_get_user_by_email_raises_invalid_project_data(self):
+        usecase = ProjectCreationUseCase(self.template_type_integration)
+
+        with self.assertRaisesMessage(InvalidProjectData, f"User with email `fake@email.com` does not exist!"):
+            usecase.get_user_by_email("fake@email.com")
+
+    def test_get_user_by_email(self):
+        usecase = ProjectCreationUseCase(self.template_type_integration)
+        user = usecase.get_user_by_email("user@marketplace.ai")
+
+        self.assertEqual(user, self.user)
+
+    def test_creating_template_project_integrate_template_type_in_project_is_called(self):
+        project_uuid = uuid.uuid4()
+        project_dto = ProjectCreationDTO(
+            uuid=project_uuid,
+            name="Fake Project",
+            is_template=True,
+            date_format="fake",
+            timezone="fake",
+            template_type_uuid=None,
+        )
+        usecase = ProjectCreationUseCase(self.template_type_integration)
+        usecase.create_project(project_dto, "user@marketplace.ai")
+
+        self.template_type_integration.integrate_template_type_in_project.assert_called_once()
+        self.assertTrue(Project.objects.filter(uuid=project_uuid).exists())
+
+    def test_create_non_template_project(self):
+        project_uuid = uuid.uuid4()
+        project_dto = ProjectCreationDTO(
+            uuid=project_uuid,
+            name="Fake Project",
+            is_template=False,
+            date_format="fake",
+            timezone="fake",
+            template_type_uuid=None,
+        )
+        usecase = ProjectCreationUseCase(self.template_type_integration)
+        usecase.create_project(project_dto, "user@marketplace.ai")
+
+        self.assertTrue(Project.objects.filter(uuid=project_uuid).exists())
+        self.template_type_integration.integrate_template_type_in_project.assert_not_called()
+
+    def test_get_or_create_project_returns_existing_project(self):
+        project_dto = ProjectCreationDTO(
+            uuid=self.project.uuid,
+            name="Fake Project",
+            is_template=False,
+            date_format="fake",
+            timezone="fake",
+            template_type_uuid=None,
+        )
+
+        usecase = ProjectCreationUseCase(self.template_type_integration)
+        project, created = usecase.get_or_create_project(project_dto, self.user)
+        self.assertEqual(project, self.project)
+        self.assertFalse(created)
+
+    def test_get_or_create_project_with_non_existent_uuid(self):
+        project_uuid = uuid.uuid4()
+        project_dto = ProjectCreationDTO(
+            uuid=project_uuid,
+            name="Fake Project",
+            is_template=False,
+            date_format="fake",
+            timezone="fake",
+            template_type_uuid=None,
+        )
+
+        usecase = ProjectCreationUseCase(self.template_type_integration)
+        project, created = usecase.get_or_create_project(project_dto, self.user)
+        self.assertTrue(created)
+        self.assertEqual(project.uuid, project_uuid)

--- a/marketplace/projects/usecases/tests/test_template_type_creation.py
+++ b/marketplace/projects/usecases/tests/test_template_type_creation.py
@@ -1,0 +1,46 @@
+import uuid
+
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+
+from marketplace.core.types import APPTYPES
+from ..template_type_creation import create_template_type
+from ...models import TemplateType
+
+
+User = get_user_model()
+
+
+class TemplateTypeCreationTestCase(TestCase):
+    def setUp(self) -> None:
+        self.project_uuid = uuid.uuid4()
+        self.user = User.objects.create_superuser(email="user@marketplace.ai")
+
+    def tests_template_type_is_created_with_the_correct_setup(self):
+        template_type_uuid = uuid.uuid4()
+        apptype = APPTYPES.get("wpp-demo")
+        apptype.create_app(created_by=self.user, project_uuid=self.project_uuid)
+
+        create_template_type(template_type_uuid, self.project_uuid, "Fake Template Type")
+
+        template_type = TemplateType.objects.get(uuid=template_type_uuid)
+        self.assertEqual(template_type.setup, {"apps": [{"code": "wpp-demo"}]})
+
+    def test_renamed_when_passing_existing_template_type_uuid(self):
+        template_type_uuid = uuid.uuid4()
+        TemplateType.objects.create(uuid=template_type_uuid, name="Fake Template Type", setup={"fake": "test"})
+
+        create_template_type(template_type_uuid, self.project_uuid, "New Name")
+
+        template_type = TemplateType.objects.get(uuid=template_type_uuid)
+        self.assertEqual(template_type.name, "New Name")
+
+    def test_ignore_apps_that_cannot_be_turned_into_template_type(self):
+        apptype = APPTYPES.get("wpp-demo")
+        apptype.create_app(created_by=self.user, project_uuid=self.project_uuid)
+
+        apptype = APPTYPES.get("wpp-cloud")
+        apptype.create_app(created_by=self.user, project_uuid=self.project_uuid)
+
+        template_type_uuid = uuid.uuid4()
+        create_template_type(template_type_uuid, self.project_uuid, "Fake Template Type")

--- a/marketplace/projects/usecases/tests/test_template_type_integration.py
+++ b/marketplace/projects/usecases/tests/test_template_type_integration.py
@@ -1,0 +1,61 @@
+import uuid
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+
+from ...models import Project, TemplateType
+from ..template_type_integration import TemplateTypeIntegrationUseCase
+from ..exceptions import InvalidTemplateTypeData
+
+
+User = get_user_model()
+
+
+class TemplateTypeIntegrationTestCase(TestCase):
+    def setUp(self) -> None:
+        self.app_setup_handler = MagicMock()
+        self.user = User.objects.create_superuser(email="user@marketplace.ai")
+        self.project = Project.objects.create(uuid=uuid.uuid4(), name="Test Project", created_by=self.user)
+
+    def test_project_already_has_template_raises_invalid_template_type_data(self):
+        template_type_uuid = uuid.uuid4()
+        template_type = TemplateType.objects.create(uuid=template_type_uuid, name="Fake Template Type")
+        self.project.template_type = template_type
+        self.project.save()
+
+        usecase = TemplateTypeIntegrationUseCase(self.app_setup_handler)
+        with self.assertRaisesMessage(
+            InvalidTemplateTypeData, f"The project `{self.project.uuid}` already has an integrated template!"
+        ):
+            usecase.integrate_template_type_in_project(self.project, template_type_uuid, self.user)
+
+    def test_send_template_type_uuid_equal_to_none_raises_invalid_template_type_data(self):
+        usecase = TemplateTypeIntegrationUseCase(self.app_setup_handler)
+        with self.assertRaisesMessage(
+            InvalidTemplateTypeData, "'template_type_uuid' cannot be empty when 'is_template' is True!"
+        ):
+            usecase.integrate_template_type_in_project(self.project, None, self.user)
+
+    def test_sending_uuid_template_type_does_not_exist_raises_invalid_template_type_data(self):
+        template_type_uuid = uuid.uuid4()
+        usecase = TemplateTypeIntegrationUseCase(self.app_setup_handler)
+        with self.assertRaisesMessage(
+            InvalidTemplateTypeData, f"Template Type with uuid `{template_type_uuid}` does not exists!"
+        ):
+            usecase.integrate_template_type_in_project(self.project, template_type_uuid, self.user)
+
+    def test_setup_apps_in_project_called_once(self):
+        template_type = TemplateType.objects.create(uuid=uuid.uuid4(), name="Fake Template Type")
+
+        usecase = TemplateTypeIntegrationUseCase(self.app_setup_handler)
+        usecase.integrate_template_type_in_project(self.project, template_type.uuid, self.user)
+        self.app_setup_handler.setup_apps_in_project.assert_called_once()
+
+    def test_integrate_template_type_in_project_assigns_template_type_in_project(self):
+        template_type_uuid = uuid.uuid4()
+        template_type = TemplateType.objects.create(uuid=template_type_uuid, name="Fake Template Type")
+
+        usecase = TemplateTypeIntegrationUseCase(self.app_setup_handler)
+        usecase.integrate_template_type_in_project(self.project, template_type_uuid, self.user)
+        self.assertEqual(self.project.template_type, template_type)


### PR DESCRIPTION
In this PR, 2 consumers are added that listen to RabbitMQ messages and execute their respective business rules:

| **Queue**                   | **Consumer class**   |
|-----------------------------|----------------------|
| integrations.template-types | TemplateTypeConsumer |
| integrations.projects       | ProjectConsumer      |

In order for the business rules to be testable and reusable, they were developed using some of the S.O.L.I.D concepts such as the Dependency Inversion Principle and the Single Responsibility Principle.