### PR TITLE
Increases the synchronization time for the sync_facebook_catalogs task

### DIFF
--- a/marketplace/settings.py
+++ b/marketplace/settings.py
@@ -368,7 +368,7 @@ CELERY_BEAT_SCHEDULE = {
     },
     "sync-facebook-catalogs": {
         "task": "sync_facebook_catalogs",
-        "schedule": timedelta(seconds=1800),
+        "schedule": timedelta(seconds=5400),
     },
 }
 


### PR DESCRIPTION
- Increases the synchronization time for the sync_facebook_catalogs task to 90 minutes