### PR TITLE
Add CRM permission to the whatsapp-cloud conversations API

### DIFF
--- a/marketplace/accounts/permissions.py
+++ b/marketplace/accounts/permissions.py
@@ -1,5 +1,6 @@
 from rest_framework import permissions
 from django.contrib.auth.models import AnonymousUser
+from django.conf import settings
 
 from .models import ProjectAuthorization
 
@@ -7,6 +8,16 @@ from .models import ProjectAuthorization
 WRITE_METHODS = ["POST"]
 MODIFY_METHODS = ["DELETE", "PATCH", "PUT"]
 READ_METHODS = ["GET"]
+
+
+def _is_crm_user(user):
+    if not settings.ALLOW_CRM_ACCESS:
+        return False
+
+    if user.email not in settings.CRM_EMAILS_LIST:
+        return False
+
+    return True
 
 
 class ProjectManagePermission(permissions.IsAuthenticated):
@@ -69,3 +80,16 @@ class ProjectViewPermission(permissions.BasePermission):
             or authorization.is_contributor
             or authorization.is_admin
         )
+
+
+class IsCRMUser(permissions.IsAuthenticated):
+    def has_permission(self, request, view) -> bool:
+        is_authenticated = super().has_permission(request, view)
+
+        if not is_authenticated:
+            return False
+
+        return _is_crm_user(request.user)
+
+    def has_object_permission(self, request, view, obj):
+        return _is_crm_user(request.user)

--- a/marketplace/core/types/channels/whatsapp_base/mixins.py
+++ b/marketplace/core/types/channels/whatsapp_base/mixins.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from rest_framework.request import Request
     from .interfaces import ProfileHandlerInterface, BusinessProfileHandlerInterface
 
-from marketplace.accounts.permissions import ProjectViewPermission
+from marketplace.accounts.permissions import ProjectViewPermission, IsCRMUser
 from .requests.facebook import FacebookConversationAPI
 from .exceptions import FacebookApiException, UnableProcessProfilePhoto
 from .serializers import WhatsAppBusinessContactSerializer, WhatsAppProfileSerializer
@@ -60,8 +60,13 @@ class WhatsAppConversationsMixin(object, metaclass=abc.ABCMeta):
     def get_access_token(self) -> dict:
         pass  # pragma: no cover
 
-    @action(detail=True, methods=["GET"], permission_classes=[ProjectViewPermission])
+    @action(
+        detail=True,
+        methods=["GET"],
+        permission_classes=[ProjectViewPermission | IsCRMUser],
+    )
     def conversations(self, request: "Request", **kwargs) -> Response:
+        self.get_object()
         date_params = QueryParamsParser(request.query_params)
 
         try:

--- a/marketplace/core/types/channels/whatsapp_cloud/views.py
+++ b/marketplace/core/types/channels/whatsapp_cloud/views.py
@@ -17,6 +17,7 @@ from marketplace.applications.models import App
 from marketplace.celery import app as celery_app
 from marketplace.connect.client import ConnectProjectClient
 from marketplace.flows.client import FlowsClient
+from marketplace.accounts.permissions import ProjectManagePermission, IsCRMUser
 
 from ..whatsapp_base import mixins
 from ..whatsapp_base.serializers import WhatsAppSerializer
@@ -38,6 +39,7 @@ class WhatsAppCloudViewSet(
     mixins.WhatsAppProfileMixin,
 ):
     serializer_class = WhatsAppSerializer
+    permission_classes = [ProjectManagePermission | IsCRMUser]
 
     business_profile_class = CloudProfileContactFacade
     profile_class = CloudProfileFacade

--- a/marketplace/settings.py
+++ b/marketplace/settings.py
@@ -421,3 +421,9 @@ if USE_EDA:
     EDA_BROKER_PORT = env.int("EDA_BROKER_PORT", default=5672)
     EDA_BROKER_USER = env("EDA_BROKER_USER", default="guest")
     EDA_BROKER_PASSWORD = env("EDA_BROKER_PASSWORD", default="guest")
+
+
+ALLOW_CRM_ACCESS = env.bool("ALLOW_CRM_ACCESS", default=False)
+
+if ALLOW_CRM_ACCESS:
+    CRM_EMAILS_LIST = env.list("CRM_EMAILS_LIST")


### PR DESCRIPTION
This pull request includes 2 new environment variables:
- `ALLOW_CRM_ACCESS`: If `True` enables API access when using the CRM user;
- `CRM_EMAILS_LIST`: List of users who will have CRM permission.