### PR TITLE
feat: change meta sync tasks to crontab

### DIFF
--- a/marketplace/settings.py
+++ b/marketplace/settings.py
@@ -360,23 +360,23 @@ CELERY_BEAT_SCHEDULE = {
     },
     "sync-whatsapp-wabas": {
         "task": "sync_whatsapp_wabas",
-        "schedule": crontab(minute=0, hour=env.int("SYNC_WHATSAPP_WABAS_HOUR", default=0)),
+        "schedule": crontab(minute=0, hour=env.int("SYNC_WHATSAPP_WABAS_HOUR", default=3)),
     },
     "sync-whatsapp-cloud-wabas": {
         "task": "sync_whatsapp_cloud_wabas",
-        "schedule": crontab(minute=0, hour=env.int("SYNC_WHATSAPP_CLOUD_WABAS_HOUR", default=1))
+        "schedule": crontab(minute=0, hour=env.int("SYNC_WHATSAPP_CLOUD_WABAS_HOUR", default=4))
     },
     "sync-whatsapp-phone-numbers": {
         "task": "sync_whatsapp_phone_numbers",
-        "schedule": crontab(minute=0, hour=env.int("SYNC_WHATSAPP_PHONE_NUMBERS_HOUR", default=2))
+        "schedule": crontab(minute=0, hour=env.int("SYNC_WHATSAPP_PHONE_NUMBERS_HOUR", default=5))
     },
     "sync-whatsapp-cloud-phone-numbers": {
         "task": "sync_whatsapp_cloud_phone_numbers",
-        "schedule": crontab(minute=0, hour=env.int("SYNC_WHATSAPP_CLOUD_PHONE_NUMBERS_HOUR", default=3))
+        "schedule": crontab(minute=0, hour=env.int("SYNC_WHATSAPP_CLOUD_PHONE_NUMBERS_HOUR", default=6))
     },
     "refresh-whatsapp-templates-from-facebook": {
         "task": "refresh_whatsapp_templates_from_facebook",
-        "schedule": crontab(minute=0, hour=env.int("REFRESH_WHATSAPP_TEMPLATES_HOUR", default=4))
+        "schedule": crontab(minute=0, hour=env.int("REFRESH_WHATSAPP_TEMPLATES_HOUR", default=7))
     },
     "check-apps-uncreated-on-flow": {
         "task": "check_apps_uncreated_on_flow",
@@ -384,7 +384,7 @@ CELERY_BEAT_SCHEDULE = {
     },
     "sync-facebook-catalogs": {
         "task": "sync_facebook_catalogs",
-        "schedule": crontab(minute=0, hour=env.int("SYNC_FACEBOOK_CATALOGS_HOUR", default=5))
+        "schedule": crontab(minute=0, hour=env.int("SYNC_FACEBOOK_CATALOGS_HOUR", default=8))
     },
     "task-cleanup-vtex-logs-and-uploads": {
         "task": "task_cleanup_vtex_logs_and_uploads",

--- a/marketplace/settings.py
+++ b/marketplace/settings.py
@@ -360,31 +360,23 @@ CELERY_BEAT_SCHEDULE = {
     },
     "sync-whatsapp-wabas": {
         "task": "sync_whatsapp_wabas",
-        "schedule": timedelta(hours=env.int("SYNC_WHATSAPP_WABAS_TIME", default=7)),
+        "schedule": crontab(minute=0, hour=env.int("SYNC_WHATSAPP_WABAS_HOUR", default=0)),
     },
     "sync-whatsapp-cloud-wabas": {
         "task": "sync_whatsapp_cloud_wabas",
-        "schedule": timedelta(
-            hours=env.int("SYNC_WHATSAPP_CLOUD_WABAS_TIME", default=4)
-        ),
+        "schedule": crontab(minute=0, hour=env.int("SYNC_WHATSAPP_CLOUD_WABAS_HOUR", default=1))
     },
     "sync-whatsapp-phone-numbers": {
         "task": "sync_whatsapp_phone_numbers",
-        "schedule": timedelta(
-            hours=env.int("SYNC_WHATSAPP_PHONE_NUMBERS_TIME", default=6)
-        ),
+        "schedule": crontab(minute=0, hour=env.int("SYNC_WHATSAPP_PHONE_NUMBERS_HOUR", default=2))
     },
     "sync-whatsapp-cloud-phone-numbers": {
         "task": "sync_whatsapp_cloud_phone_numbers",
-        "schedule": timedelta(
-            hours=env.int("SYNC_WHATSAPP_CLOUD_PHONE_NUMBERS_TIME", default=5)
-        ),
+        "schedule": crontab(minute=0, hour=env.int("SYNC_WHATSAPP_CLOUD_PHONE_NUMBERS_HOUR", default=3))
     },
     "refresh-whatsapp-templates-from-facebook": {
         "task": "refresh_whatsapp_templates_from_facebook",
-        "schedule": timedelta(
-            seconds=env.int("REFRESH_WHATSAPP_TEMPLATES_TIME", default=1800)
-        ),
+        "schedule": crontab(minute=0, hour=env.int("REFRESH_WHATSAPP_TEMPLATES_HOUR", default=4))
     },
     "check-apps-uncreated-on-flow": {
         "task": "check_apps_uncreated_on_flow",
@@ -392,9 +384,7 @@ CELERY_BEAT_SCHEDULE = {
     },
     "sync-facebook-catalogs": {
         "task": "sync_facebook_catalogs",
-        "schedule": timedelta(
-            seconds=env.int("SYNC_FACEBOOK_CATALOGS_TIME", default=5400)
-        ),
+        "schedule": crontab(minute=0, hour=env.int("SYNC_FACEBOOK_CATALOGS_HOUR", default=5))
     },
     "task-cleanup-vtex-logs-and-uploads": {
         "task": "task_cleanup_vtex_logs_and_uploads",


### PR DESCRIPTION
Modified Meta related tasks to use crontab instead of timedelta, to ensure that those tasks will only be executed in an appropriate time

Default hours in UTC-3:

```
00:00  SYNC_WHATSAPP_WABAS_HOUR
01:00  SYNC_WHATSAPP_CLOUD_WABAS_HOUR
02:00  SYNC_WHATSAPP_PHONE_NUMBERS_HOUR
03:00  SYNC_WHATSAPP_CLOUD_PHONE_NUMBERS_HOUR
04:00  REFRESH_WHATSAPP_TEMPLATES_HOUR
05:00  SYNC_FACEBOOK_CATALOGS_HOUR
```