### PR TITLE
Fix: Ensure Proper Spacing After Periods in Titles and Descriptions

### DIFF
--- a/marketplace/services/vtex/utils/data_processor.py
+++ b/marketplace/services/vtex/utils/data_processor.py
@@ -59,6 +59,8 @@ class DataProcessor:
         text = re.sub(r"[ \t]+", " ", text.strip())
         # Remove bullet points
         text = text.replace("•", "")
+        # Ensure there's a space after a period, unless followed by a new line
+        text = re.sub(r"\.(?=[^\s\n])", ". ", text)
         return text
 
     @staticmethod


### PR DESCRIPTION
This fix solve the error ""forno.com" on upload product feed to facebook