### PR TITLE
fix: Whatsapp cloud sync beat

### DIFF
--- a/marketplace/settings.py
+++ b/marketplace/settings.py
@@ -363,6 +363,10 @@ USE_GRPC = env.bool("USE_GRPC", default=False)
 CELERY_BEAT_SCHEDULE = {
     "sync-whatsapp-apps": {
         "task": "sync_whatsapp_apps",
+        "schedule": timedelta(hours=3),
+    },
+    "sync-whatsapp-cloud-apps": {
+        "task": "sync_whatsapp_cloud_apps",
         "schedule": timedelta(hours=2),
     },
     "sync-whatsapp-wabas": {


### PR DESCRIPTION
- Add `sync_whatsapp_cloud_apps` task to celery beat.
- Update `sync_whatsapp_cloud` to run every 3 hours.