### PR TITLE
fix: Missing TTL on Redis sync lock for WhatsApp phone number and Waba

### DIFF
--- a/marketplace/core/types/channels/whatsapp/usecases/phone_number_sync.py
+++ b/marketplace/core/types/channels/whatsapp/usecases/phone_number_sync.py
@@ -147,5 +147,5 @@ class PhoneNumberSyncUseCase:
         self.redis_conn.set(
             key,
             "synced",
-            settings.WHATSAPP_TIME_BETWEEN_SYNC_PHONE_NUMBERS_IN_HOURS,
+            ex=settings.WHATSAPP_TIME_BETWEEN_SYNC_PHONE_NUMBERS_IN_HOURS,
         )

--- a/marketplace/core/types/channels/whatsapp/usecases/waba_sync.py
+++ b/marketplace/core/types/channels/whatsapp/usecases/waba_sync.py
@@ -118,5 +118,5 @@ class WABASyncUseCase:
         self.redis_conn.set(
             key,
             "synced",
-            settings.WHATSAPP_TIME_BETWEEN_SYNC_WABA_IN_HOURS,
+            ex=settings.WHATSAPP_TIME_BETWEEN_SYNC_WABA_IN_HOURS,
         )


### PR DESCRIPTION
Fix missing TTL on Redis sync lock for WhatsApp phone number and waba.