### PR TITLE
fix: ignore VTEX 404 and 500 exceptions on product sync

### DIFF
--- a/marketplace/services/vtex/utils/data_processor.py
+++ b/marketplace/services/vtex/utils/data_processor.py
@@ -386,9 +386,15 @@ class ProductProcessor:
                 return []
             return [dto]
         except CustomAPIException as e:
-            logger.error(
-                f"Error processing SKU {sku_id} (seller {seller_id}): {str(e)}"
-            )
+            if e.status_code in (404, 500):
+                logger.info(
+                    f"SKU {sku_id} returned status: {e.status_code}. Skipping. func: process_seller_sku"
+                )
+            else:
+                logger.error(
+                    f"Error processing SKU {sku_id}: {str(e)}. func: process_seller_sku",
+                    exc_info=True,
+                )
             return []
 
     def process_single_sku(
@@ -482,7 +488,15 @@ class ProductProcessor:
 
             return results
         except CustomAPIException as e:
-            logger.error(f"Error processing SKU {sku_id}: {str(e)}")
+            if e.status_code in (404, 500):
+                logger.info(
+                    f"SKU {sku_id} returned status: {e.status_code}. Skipping. func: process_single_sku"
+                )
+            else:
+                logger.error(
+                    f"Error processing SKU {sku_id}: {str(e)}. func: process_single_sku",
+                    exc_info=True,
+                )
             return []
 
 


### PR DESCRIPTION
- Handle VTEX API 404/500 errors as business events, not errors
- Log 404/500 as info instead of error
- Prevent Sentry noise and unnecessary retries for these statuses
- Processing now skips products with 404/500 without raising exceptions